### PR TITLE
Only run Cloudinary loadScript once

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -22,7 +22,7 @@ const App = () => {
   useEffect(() => {
     // Load all cloudinary scripts
     loadScript('https://widget.cloudinary.com/v2.0/global/all.js')
-  })
+  }, [])
 
   // Return the header and either show an error or render the loaded profiles.
   return (


### PR DESCRIPTION
Adding an empty array to the useEffect function so it doesn't run on every re-render. This makes it so the useEffect is only run once.. when the user first loads the page or refreshes.