### PR TITLE
Moved onClick handler for creating new fweet to button

### DIFF
--- a/src/components/fweeter.js
+++ b/src/components/fweeter.js
@@ -55,8 +55,8 @@ const Fweeter = props => {
       {asset ? <Asset asset={asset}></Asset> : null}
       <div className="fweet-card-actions">
         <div className="icon">{generateUploadImage()}</div>
-        <button className="icon">
-          <FontAwesomeIcon icon={faPaperPlane} onClick={handleSubmit} />
+        <button className="icon" onClick={handleSubmit}>
+          <FontAwesomeIcon icon={faPaperPlane} />
         </button>
       </div>
     </div>

--- a/src/components/fweeter.js
+++ b/src/components/fweeter.js
@@ -19,6 +19,8 @@ const Fweeter = props => {
 
   const handleSubmit = event => {
     event.preventDefault()
+    
+    if (!fweet) return
     props.handleCreateFweet(fweet, asset).then(e => {
       setFweet('')
       setAsset(null)


### PR DESCRIPTION
The onClick handler for creating a new fweet was on the icon instead of the button. Before.. you had to carefully click on the icon to send the fweet :P