### PR TITLE
Rename handle var to alias for easier code searching

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -37,7 +37,7 @@ const App = () => {
               <Route exact path="/accounts/register">
                 <Register />
               </Route>
-              <Route path="/users/:authorHandle" component={User} />
+              <Route path="/users/:authorAlias" component={User} />
               <Route path="/tags/:tag" component={Tag} />
               <Route path="/">
                 <Home />

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -24,10 +24,10 @@ const Card = props => {
           <div className="fweet-card-text">
             <p className="fweet-description"> {fweetAndMore.fweet.message} </p>
           </div>
-          <div className="fweet-card-text refweet">
+          <div className="fweet-card-text refweet">          
             <div className="fweet-header">
               <span className="fweet-name"> {fweetAndMore.original.user.name} </span>
-              <span className="fweet-handle"> @{fweetAndMore.original.user.handle} </span>
+              <span className="fweet-alias"> @{fweetAndMore.original.user.alias} </span>
             </div>
             <p className="fweet-description"> {fweetAndMore.original.fweet.message} </p>
           </div>
@@ -42,7 +42,7 @@ const Card = props => {
           <div className="fweet-card-text">
             <div className="fweet-header">
               <span className="fweet-name"> {fweetAndMore.user.name} </span>
-              <span className="fweet-handle"> @{fweetAndMore.user.handle} </span>
+              <span className="fweet-alias"> @{fweetAndMore.user.alias} </span>
             </div>
             <p className="fweet-description"> {fweetAndMore.fweet.message} </p>
           </div>
@@ -60,7 +60,7 @@ const Card = props => {
           <div className="fweet-card-text comment" key={commandAndAuthor.comment.ref.toString()}>
             <div className="fweet-header">
               <span className="fweet-name"> {commandAndAuthor.author.name} </span>
-              <span className="fweet-handle"> @{commandAndAuthor.author.handle} </span>
+              <span className="fweet-alias"> @{commandAndAuthor.author.alias} </span>
             </div>
             <p className="fweet-description"> {commandAndAuthor.comment.message} </p>
           </div>

--- a/src/components/form.js
+++ b/src/components/form.js
@@ -6,7 +6,7 @@ const Form = props => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [name, setName] = useState('')
-  const [handle, setHandle] = useState('')
+  const [alias, setAlias] = useState('')
 
   const handleChangeUserName = event => {
     setUsername(event.target.value)
@@ -20,8 +20,8 @@ const Form = props => {
     setName(event.target.value)
   }
 
-  const handleChangeHandle = event => {
-    setHandle(event.target.value)
+  const handleChangeAlias = event => {
+    setAlias(event.target.value)
   }
 
   const linkInfo = props.isLogin
@@ -31,11 +31,11 @@ const Form = props => {
   return (
     <React.Fragment>
       <div className="account-form-container">
-        <form className="account-form" onSubmit={e => props.handleSubmit(e, username, password, handle, name)}>
-          {props.isLogin ? null : renderInputField('Name', name, 'text', e => handleChangeName(e))}
-          {props.isLogin ? null : renderInputField('Handle', handle, 'text', e => handleChangeHandle(e))}
+        <form className="account-form" onSubmit={e => props.handleSubmit(e, username, password, alias, name)}>
+         {props.isLogin ? null : renderInputField('Name', name, 'text', e => handleChangeName(e))}
+          {props.isLogin ? null : renderInputField('Alias', alias, 'text', e => handleChangeAlias(e))}
           {renderInputField('Email', username, 'text', e => handleChangeUserName(e))}
-          {renderInputField('Password', password, 'password', e => handleChangePassword(e))}
+          {renderInputField('Password', password, 'password', e => handleChangePassword(e))}          
           <div className="input-row align-right">
             <Link to={linkInfo.link}> {linkInfo.linkText}</Link>
             <button className={props.isLogin ? 'login' : 'register'}> {props.isLogin ? 'Login' : 'Register'} </button>
@@ -50,7 +50,7 @@ const renderInputField = (name, value, type, fun) => {
   const lowerCaseName = name.toLowerCase()
   return (
     <div className="input-row">
-      <span className="input-row-column">{name}</span>
+      <label htmlFor="{lowerCaseName}" className="input-row-column">{name}</label>
       <input
         className="input-row-column"
         autoComplete={lowerCaseName}

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -31,7 +31,7 @@ const Search = props => {
   }
 
   const handleUserClick = (event, searchResult) => {
-    history.push(`/users/${searchResult.handle}`)
+    history.push(`/users/${searchResult.alias}`)
 
     event.stopPropagation()
   }
@@ -69,11 +69,11 @@ const Search = props => {
         <React.Fragment>
           <div className="search-results">
             <div className="search-results-title">People</div>
-            <div className="search-results-people">{renderUserResults(searchResults.filter(e => e.handle))}</div>
+            <div className="search-results-people">{renderUserResults(searchResults.filter(e => e.alias))}</div>
           </div>
           <div className="search-results">
             <div className="search-results-title">Tags</div>
-            <div className="search-results-tags">{renderTagResults(searchResults.filter(e => !e.handle))}</div>
+            <div className="search-results-tags">{renderTagResults(searchResults.filter(e => !e.alias))}</div>
           </div>
         </React.Fragment>
       )
@@ -90,9 +90,9 @@ const Search = props => {
           <div className="avatar">
             <img className="avatar-image" src={`/images/${res.icon}.png`} alt="profile" />
           </div>
-          <div className="search-result-name-and-handle">
+          <div className="search-result-name-and-alias">
             <div className="name">{res.name}</div>
-            <div className="handle">@{res.handle}</div>
+            <div className="alias">@{res.alias}</div>
           </div>
           <div className="search-result-follow-button" onClick={event => handleFollowUser(event, res)}>
             <button className="icon">

--- a/src/fauna/helpers/errors.js
+++ b/src/fauna/helpers/errors.js
@@ -23,7 +23,7 @@ const wrapPromiseError = (promise, entity) => {
     })
 }
 
-const handle = (promise, tag, printData) => {
+const alias = (promise, tag, printData) => {
   return promise
     .then(data => {
       // console.log('Success call:' + tag)
@@ -64,4 +64,4 @@ const safeVerifyError = (error, keys) => {
   }
   return error
 }
-export { handlePromiseError, wrapPromiseError, handle, handleSetupError, safeVerifyError }
+export { handlePromiseError, wrapPromiseError, alias, handleSetupError, safeVerifyError }

--- a/src/fauna/queries/auth.js
+++ b/src/fauna/queries/auth.js
@@ -75,13 +75,13 @@ function RegisterAccountExample2(email, password) {
  * However, we also want to create a user automatically when we create an account.
  * We can use a Let to structure our query */
 // eslint-disable-next-line no-unused-vars
-function RegisterExample3(email, password, name, handle, icon, rateLimiting = true) {
+function RegisterExample3(email, password, name, alias, icon, rateLimiting = true) {
   const RegisterFQLStatement = Let(
     {
       user: Create(Collection('users'), {
         data: {
           name: name,
-          handle: handle,
+          alias: alias,
           icon: icon
         }
       }),
@@ -107,7 +107,7 @@ function RegisterExample3(email, password, name, handle, icon, rateLimiting = tr
 /* Register Example4 - let's extend it to do e-mail validation 
    And follow ourselves at the moment we create the user 
    since you only see the feed of the people you follow */
-function RegisterWithUser(email, password, name, handle, icon, rateLimiting = true) {
+function RegisterWithUser(email, password, name, alias, icon, rateLimiting = true) {
   // It's always a good idea to use If for such validations compared to Do since Do is not short-circuited at this point
   // at the read-phase, which means that you will incur more reads.
   const ValidateEmail = FqlStatement =>
@@ -136,7 +136,7 @@ function RegisterWithUser(email, password, name, handle, icon, rateLimiting = tr
       user: Create(Collection('users'), {
         data: {
           name: name,
-          handle: handle,
+          alias: alias,
           icon: icon
         }
       }),
@@ -269,9 +269,9 @@ function register(client, email, password) {
   return client.query(Call(q.Function('register'), email, password)).then(res => flattenDataKeys(res))
 }
 
-function registerWithUser(client, email, password, name, handle, icon) {
+function registerWithUser(client, email, password, name, alias, icon) {
   return client
-    .query(Call(q.Function('register_with_user'), email, password, name, handle, icon))
+    .query(Call(q.Function('register_with_user'), email, password, name, alias, icon))
     .then(res => flattenDataKeys(res))
 }
 

--- a/src/fauna/queries/auth.spec.js
+++ b/src/fauna/queries/auth.spec.js
@@ -4,7 +4,7 @@ import { CreateOrUpdateFunction, CreateAccountUDF } from './../setup/functions'
 import { setupProtectedResource, setupDatabaseAuthSpec, deleteAndCreateDatabase } from '../setup/database'
 import { DeleteAllAccounts } from '../setup/accounts'
 
-import { handle, wrapPromiseError } from './../helpers/errors'
+import { alias, wrapPromiseError } from './../helpers/errors'
 import { register, login } from './auth'
 
 // About this spec:
@@ -24,14 +24,14 @@ beforeAll(async () => {
     const adminClient = new faunadb.Client({
       secret: process.env.REACT_APP_TEST__ADMIN_KEY
     })
-    const secret = await handle(deleteAndCreateDatabase(adminClient, 'auth-spec'), 'Creating temporary test database')
+    const secret = await alias(deleteAndCreateDatabase(adminClient, 'auth-spec'), 'Creating temporary test database')
     client = new faunadb.Client({
       secret: secret
     })
     // Setup the database for this test.
-    await handle(setupDatabaseAuthSpec(client), 'Setup Database')
+    await alias(setupDatabaseAuthSpec(client), 'Setup Database')
     // Set up a resource that we should only be able to access after logging in.
-    misterProtectedRef = await handle(setupProtectedResource(client), 'Setup a protected collection and entity')
+    misterProtectedRef = await alias(setupProtectedResource(client), 'Setup a protected collection and entity')
   } catch (err) {
     console.error(err)
   }

--- a/src/fauna/queries/fweets.js
+++ b/src/fauna/queries/fweets.js
@@ -417,12 +417,12 @@ function getFweetsByTag(client, tag) {
   return client.query(Call(q.Function('get_fweets_by_tag'), tag)).then(res => flattenDataKeys(res))
 }
 
-function GetFweetsByAuthor(authorHandle) {
+function GetFweetsByAuthor(authorAlias) {
   const FQLStatement = Let(
     {
-      // We only receive the userHandle, not reference (since this is passed through the URL, a ref would be ugly in the url right?)
+      // We only receive the userAlias, not reference (since this is passed through the URL, a ref would be ugly in the url right?)
       // So let's get the user, we assume that it still exists (if not Get will error but that is fine for our use case)
-      authorReference: Select([0], Paginate(Match(Index('users_by_handle'), authorHandle))),
+      authorReference: Select([0], Paginate(Match(Index('users_by_alias'), authorAlias))),
       results: GetFweetsWithUsersMapGetGeneric(
         // When we look at the feed of fweets of a certain user, we are just going to order them
         // Chronologically.
@@ -439,8 +439,8 @@ function GetFweetsByAuthor(authorHandle) {
   return AddRateLimiting('get_fweets_by_author', FQLStatement, Identity())
 }
 
-function getFweetsByAuthor(client, authorHandle) {
-  return client.query(Call(q.Function('get_fweets_by_author'), authorHandle)).then(res => flattenDataKeys(res))
+function getFweetsByAuthor(client, authorAlias) {
+  return client.query(Call(q.Function('get_fweets_by_author'), authorAlias)).then(res => flattenDataKeys(res))
 }
 
 /* Get fweets and the user that is the author of the message.

--- a/src/fauna/queries/fweets.spec.js
+++ b/src/fauna/queries/fweets.spec.js
@@ -2,7 +2,7 @@ import faunadb from 'faunadb'
 
 import { setupDatabase, deleteAndCreateDatabase } from '../setup/database'
 
-import { handle } from './../helpers/errors'
+import { alias } from './../helpers/errors'
 import { registerWithUser, login } from './auth'
 import { getFweets, createFweet, createFweetWithoutUDF } from './fweets'
 import { follow } from './followers'
@@ -29,7 +29,7 @@ beforeAll(async () => {
       secret: process.env.REACT_APP_TEST__ADMIN_KEY
     })
     // Create the admin client for the new database to bootstrap things
-    const secret = await handle(
+    const secret = await alias(
       deleteAndCreateDatabase(adminClientParentDb, 'fweets-spec'),
       'Creating temporary test database'
     )
@@ -37,26 +37,26 @@ beforeAll(async () => {
       secret: secret
     })
     // Setup the database for this test.
-    await handle(setupDatabase(adminClient), 'Setup Database')
+    await alias(setupDatabase(adminClient), 'Setup Database')
 
     // Create a client with a login key (getting privileges from 'memberships' in roles)
     // We create a user directly as well
-    await handle(registerWithUser(adminClient, 'test@test.com', 'testtest'), 'Register with User')
-    const res = await handle(login(adminClient, 'test@test.com', 'testtest'), 'Login')
+    await alias(registerWithUser(adminClient, 'test@test.com', 'testtest'), 'Register with User')
+    const res = await alias(login(adminClient, 'test@test.com', 'testtest'), 'Login')
     loggedInClient = new faunadb.Client({ secret: res.secret })
     user1Ref = res.user.ref
 
-    await handle(registerWithUser(adminClient, 'test2@test.com', 'testtest'), 'Register with User')
-    const res2 = await handle(login(adminClient, 'test2@test.com', 'testtest'), 'Login')
+    await alias(registerWithUser(adminClient, 'test2@test.com', 'testtest'), 'Register with User')
+    const res2 = await alias(login(adminClient, 'test2@test.com', 'testtest'), 'Login')
     loggedInClient2 = new faunadb.Client({ secret: res2.secret })
 
     // Create a client with the bootstrap key (assuming the bootstrap role)
-    const key = await handle(adminClient.query(CreateKey({ role: Role('keyrole_calludfs') })), 'Creating Bootstrap Key')
+    const key = await alias(adminClient.query(CreateKey({ role: Role('keyrole_calludfs') })), 'Creating Bootstrap Key')
     bootstrapClient = new faunadb.Client({ secret: key.secret })
 
     user2Ref = res2.user.ref
-    await handle(createFweet(loggedInClient, 'Tweet user 1 #tag1', ['tag1']), 'Creating Fweet 1')
-    await handle(createFweet(loggedInClient2, 'Tweet user 2 #tag2 #tag3', ['tag2', 'tag3']), 'Creating Fweet 2')
+    await alias(createFweet(loggedInClient, 'Tweet user 1 #tag1', ['tag1']), 'Creating Fweet 1')
+    await alias(createFweet(loggedInClient2, 'Tweet user 2 #tag2 #tag3', ['tag2', 'tag3']), 'Creating Fweet 2')
 
     return
     // Set up a resource that we should only be able to access after logging in.

--- a/src/fauna/queries/rate-limiting.spec.js
+++ b/src/fauna/queries/rate-limiting.spec.js
@@ -5,7 +5,7 @@ import { DeleteAllRatelimiting } from '../setup/rate-limiting'
 import { DeleteAllAccounts } from '../setup/accounts'
 import { DeleteAllUsers } from '../setup/users'
 import { registerWithUser, login } from './auth'
-import { handle } from './../helpers/errors'
+import { alias } from './../helpers/errors'
 
 // the rate-limiting function we are actually testing
 import { AddRateLimiting } from './rate-limiting'
@@ -35,7 +35,7 @@ beforeAll(async () => {
     adminClient = new faunadb.Client({
       secret: process.env.REACT_APP_TEST__ADMIN_KEY
     })
-    const secret = await handle(
+    const secret = await alias(
       deleteAndCreateDatabase(adminClient, 'ratelimiting-spec'),
       'Creating temporary test database'
     )
@@ -44,7 +44,7 @@ beforeAll(async () => {
       secret: secret
     })
     // Setup the database for this test
-    await handle(setupDatabaseRateLimitingSpec(adminClient), 'Setup Database')
+    await alias(setupDatabaseRateLimitingSpec(adminClient), 'Setup Database')
   } catch (err) {
     console.error(err)
   }

--- a/src/fauna/queries/search.spec.js
+++ b/src/fauna/queries/search.spec.js
@@ -5,13 +5,13 @@ import { DeleteAllRatelimiting } from '../setup/rate-limiting'
 import { DeleteAllAccounts } from '../setup/accounts'
 import { DeleteAllUsers } from '../setup/users'
 import { registerWithUser, login } from './auth'
-import { handle } from './../helpers/errors'
+import { alias } from './../helpers/errors'
 import { searchPeopleAndTags } from './search'
 import { CreateHashtags } from './hashtags'
 // About this spec:
 // --------------------
 // This spec shows how the autocompletion search worls.
-// A search that searches over multiple collections, in this case user handles and tags (indexes can range over multiple collections)
+// A search that searches over multiple collections, in this case user aliass and tags (indexes can range over multiple collections)
 // It's based on bindings which is like a calculated value.
 // That means that the value to search for is automatically transformed to the 'ngrams' that support the search
 
@@ -45,13 +45,13 @@ beforeAll(async () => {
     adminClient = new faunadb.Client({
       secret: process.env.REACT_APP_TEST__ADMIN_KEY
     })
-    const secret = await handle(deleteAndCreateDatabase(adminClient, 'search-spec'), 'Creating temporary test database')
+    const secret = await alias(deleteAndCreateDatabase(adminClient, 'search-spec'), 'Creating temporary test database')
     // Scope key to the new database
     adminClient = new faunadb.Client({
       secret: secret
     })
     // Setup the database for this test
-    await handle(setupDatabaseSearchSpec(adminClient), 'Setup Database')
+    await alias(setupDatabaseSearchSpec(adminClient), 'Setup Database')
   } catch (err) {
     console.error(err)
   }
@@ -67,8 +67,8 @@ beforeEach(async () => {
     // register two test users
     await waitForIndexActive(adminClient, 'hashtags_and_users_by_wordparts')
     // we will search on the names of users (the second last parameter)
-    await registerWithUser(adminClient, 'test@test.com', 'testtest', 'MrStrawberry', 'userHandle1')
-    await registerWithUser(adminClient, 'test2@test.com', 'testtest', 'SirPepper', 'userHandle2')
+    await registerWithUser(adminClient, 'test@test.com', 'testtest', 'MrStrawberry', 'useralias1')
+    await registerWithUser(adminClient, 'test2@test.com', 'testtest', 'SirPepper', 'useralias2')
     // and the hashtags
     await adminClient.query(CreateHashtags(['Berries']))
     await adminClient.query(CreateHashtags(['Pepper', 'Raw Honey']))
@@ -78,7 +78,7 @@ beforeEach(async () => {
   }
 }, 1200000)
 
-it('We can autocomplete tags and user handles', function() {
+it('We can autocomplete tags and user aliass', function() {
   let loggedInClient = null
 
   return (
@@ -86,7 +86,7 @@ it('We can autocomplete tags and user handles', function() {
       .then(res => {
         loggedInClient = new faunadb.Client({ secret: res.secret })
       })
-      // We can search for these users by a part of their handle
+      // We can search for these users by a part of their alias
       // We only search for lowercase!
       .then(res => {
         return searchPeopleAndTags(loggedInClient, 'mrstraw').then(res => {

--- a/src/fauna/query-manager.js
+++ b/src/fauna/query-manager.js
@@ -39,10 +39,10 @@ class QueryManager {
     })
   }
 
-  register(email, password, name, handle) {
+  register(email, password, name, alias) {
     // randomly choose an icon
     const icon = 'person' + (Math.round(Math.random() * 22) + 1)
-    return registerWithUser(this.client, email, password, name, handle, icon).then(res => {
+    return registerWithUser(this.client, email, password, name, alias, icon).then(res => {
       if (res) {
         this.client = new faunadb.Client({ secret: res.secret.secret })
       }

--- a/src/fauna/setup/database.js
+++ b/src/fauna/setup/database.js
@@ -39,7 +39,7 @@ import { createFweetStatsCollection } from './fweetstats'
 import { createFollowerStatsCollection } from './followerstats'
 import { createCommentsCollection } from './comments'
 
-import { handle, handleSetupError } from '../helpers/errors'
+import { alias, handleSetupError } from '../helpers/errors'
 
 const q = faunadb.query
 const { Collection, CreateCollection, Create, If, Exists, Database, CreateDatabase, CreateKey, Delete, Do } = q
@@ -49,11 +49,11 @@ const { Collection, CreateCollection, Create, If, Exists, Database, CreateDataba
 // Here we insert the lambdas into the database as User Defined Functions (UDF) or a sort of stored procedure.
 
 async function deleteAndCreateDatabase(client, name) {
-  const database = await handle(
+  const database = await alias(
     client.query(Do(If(Exists(Database(name)), Delete(Database(name)), false), CreateDatabase({ name: name }))),
     'Deleting and recreate database'
   )
-  const adminKey = await handle(
+  const adminKey = await alias(
     client.query(CreateKey({ database: database.ref, role: 'admin' })),
     'Create Admin key for db'
   )
@@ -127,16 +127,16 @@ async function setupDatabaseRateLimitingSpec(client) {
 }
 
 async function setupDatabaseAuthSpec(client) {
-  await handle(createAccountCollection(client), 'Create Accounts Collection')
-  await handle(createUsersCollection(client), 'Create Users Collection')
-  await handle(createRateLimitingCollection(client), 'Create Rate Limiting Collection')
+  await alias(createAccountCollection(client), 'Create Accounts Collection')
+  await alias(createUsersCollection(client), 'Create Users Collection')
+  await alias(createRateLimitingCollection(client), 'Create Rate Limiting Collection')
   await handleSetupError(createFollowerStatsCollection(client), 'followerstats collection')
-  await handle(client.query(CreateFnRoleLoginWithoutRateLimiting), 'Create Login Fn role (no rate limiting)')
-  await handle(client.query(CreateFnRoleRegisterWithoutRateLimiting), 'Create Register Fn role (no rate limiting)')
-  await handle(client.query(CreateLoginSimpleUDF), 'Create Login UDF')
-  await handle(client.query(CreateAccountUDF), 'Create Account UDF')
-  await handle(client.query(CreateBootstrapRoleSimple), 'Create Bootstrap Role')
-  await handle(client.query(CreatePowerlessRole), 'Create Powerless Role')
+  await alias(client.query(CreateFnRoleLoginWithoutRateLimiting), 'Create Login Fn role (no rate limiting)')
+  await alias(client.query(CreateFnRoleRegisterWithoutRateLimiting), 'Create Register Fn role (no rate limiting)')
+  await alias(client.query(CreateLoginSimpleUDF), 'Create Login UDF')
+  await alias(client.query(CreateAccountUDF), 'Create Account UDF')
+  await alias(client.query(CreateBootstrapRoleSimple), 'Create Bootstrap Role')
+  await alias(client.query(CreatePowerlessRole), 'Create Powerless Role')
 }
 
 async function setupDatabaseSearchSpec(client) {
@@ -163,13 +163,13 @@ async function setupDatabaseSearchSpec(client) {
 
 async function setupProtectedResource(client) {
   let misterProtectedRef
-  await handle(
+  await alias(
     client.query(
       If(Exists(Collection('something_protected')), true, CreateCollection({ name: 'something_protected' }))
     ),
     'Create protected collection'
   )
-  await handle(
+  await alias(
     client.query(Create(Collection('something_protected'), { data: { name: 'mister-protected' } })).then(res => {
       misterProtectedRef = res.ref
     }),

--- a/src/fauna/setup/functions.js
+++ b/src/fauna/setup/functions.js
@@ -52,8 +52,8 @@ const CreateAccountWithUserUDF = CreateOrUpdateFunction({
   name: 'register_with_user',
   body: Query(
     Lambda(
-      ['email', 'password', 'name', 'handle', 'icon'],
-      RegisterWithUser(Var('email'), Var('password'), Var('name'), Var('handle'), Var('icon'))
+      ['email', 'password', 'name', 'alias', 'icon'],
+      RegisterWithUser(Var('email'), Var('password'), Var('name'), Var('alias'), Var('icon'))
     )
   ),
   role: Role('functionrole_register_with_user')
@@ -63,8 +63,8 @@ const CreateAccountWithUserNoRatelimitingUDF = CreateOrUpdateFunction({
   name: 'register_with_user',
   body: Query(
     Lambda(
-      ['email', 'password', 'name', 'handle', 'icon'],
-      RegisterWithUser(Var('email'), Var('password'), Var('name'), Var('handle'), Var('icon'), false)
+      ['email', 'password', 'name', 'alias', 'icon'],
+      RegisterWithUser(Var('email'), Var('password'), Var('name'), Var('alias'), Var('icon'), false)
     )
   ),
   role: Role('functionrole_register_with_user')

--- a/src/fauna/setup/roles.js
+++ b/src/fauna/setup/roles.js
@@ -375,7 +375,7 @@ const CreateFnRoleManipulateFweet = CreateOrUpdateRole({
       actions: { read: true }
     },
     {
-      resource: Index('users_by_handle'),
+      resource: Index('users_by_alias'),
       actions: { read: true }
     }
   ]

--- a/src/fauna/setup/searching.js
+++ b/src/fauna/setup/searching.js
@@ -105,7 +105,7 @@ const CreateHashtagsByWordpartsWithBinding = CreateIndex({
 
 // --- Step 3 ---
 // We can index multiple collections !
-// We want to search for user handles as well, not only for tagS!
+// We want to search for user aliass as well, not only for tagS!
 // Since we can put multiple collections in one index, we can do that.
 // In this case we decided to let users and accounts have the same property 'wordparts'.
 // the users property has a different name, we can easily fix that with bindings as well.
@@ -118,7 +118,7 @@ const CreateHashtagsAndUsersByWordpartsWithBinding = CreateIndex({
       fields: {
         // We can use bindings to make sure that fields of different collections
         // have the same name in our index (e.g. in case wordparts in users and hashtags)
-        // would be stored slightly differently (user has an extra key in the path 'handle' in the below example)
+        // would be stored slightly differently (user has an extra key in the path 'alias' in the below example)
         length: Query(Lambda('hashtag', Length(Select(['data', 'name'], Var('hashtag'))))),
         wordparts: Query(Lambda('hashtag', Select(['data', 'wordparts'], Var('hashtag'))))
       }
@@ -126,8 +126,8 @@ const CreateHashtagsAndUsersByWordpartsWithBinding = CreateIndex({
     {
       collection: Collection('users'),
       fields: {
-        length: Query(Lambda('user', Length(Select(['data', 'handle', 'name'], Var('user'))))),
-        wordparts: Query(Lambda('user', Select(['data', 'handle', 'wordparts'], Var('user'))))
+        length: Query(Lambda('user', Length(Select(['data', 'alias', 'name'], Var('user'))))),
+        wordparts: Query(Lambda('user', Select(['data', 'alias', 'wordparts'], Var('user'))))
       }
     }
   ],
@@ -233,9 +233,9 @@ const CreateHashtagsAndUsersByWordpartsWithBinding3 = CreateIndex({
           Lambda(
             'user',
             Union(
-              // We'll search both on the name as the handle.
+              // We'll search both on the name as the alias.
               Union(WordPartGenerator(Select(['data', 'name'], Var('user')))),
-              Union(WordPartGenerator(Select(['data', 'handle'], Var('user'))))
+              Union(WordPartGenerator(Select(['data', 'alias'], Var('user'))))
             )
           )
         )

--- a/src/fauna/setup/users.js
+++ b/src/fauna/setup/users.js
@@ -1,4 +1,4 @@
-import { handle } from '../helpers/errors'
+import { alias } from '../helpers/errors'
 const faunadb = require('faunadb')
 const q = faunadb.query
 const { CreateCollection, CreateIndex, Collection, Exists, If, Index, Delete, Lambda, Paginate, Match, Var } = q
@@ -39,17 +39,17 @@ const CreateUsersByAccount = CreateIndex({
   serialized: true
 })
 
-const CreateUsersByHandle = CreateIndex({
-  name: 'users_by_handle',
+const CreateUsersByAlias = CreateIndex({
+  name: 'users_by_alias',
   source: Collection('users'),
-  // We will search on the handle
+  // We will search on the alias
   terms: [
     {
-      field: ['data', 'handle']
+      field: ['data', 'alias']
     }
   ],
   // no values are added, we'll just return the reference.
-  // unique prevents that two users have the same handle!
+  // unique prevents that two users have the same alias!
   unique: true,
   serialized: true
 })
@@ -61,29 +61,29 @@ const DeleteAllUsers = If(
 )
 
 async function createUsersCollection(client) {
-  await handle(client.query(If(Exists(Collection('users')), true, CreateUsersCollection)), 'Creating users collection')
-  await handle(client.query(If(Exists(Index('all_users')), true, CreateIndexAllUsers)), 'Creating all_users index')
-  await handle(
-    client.query(If(Exists(Index('users_by_handle')), true, CreateUsersByHandle)),
-    'Creating users_by_handle index'
+  await alias(client.query(If(Exists(Collection('users')), true, CreateUsersCollection)), 'Creating users collection')
+  await alias(client.query(If(Exists(Index('all_users')), true, CreateIndexAllUsers)), 'Creating all_users index')
+  await alias(
+    client.query(If(Exists(Index('users_by_alias')), true, CreateUsersByAlias)),
+    'Creating users_by_alias index'
   )
-  await handle(
+  await alias(
     client.query(If(Exists(Index('users_by_account')), true, CreateUsersByAccount)),
     'Creating users_by_account index'
   )
 }
 
 async function deleteUsersCollection(client) {
-  await handle(
+  await alias(
     client.query(If(Exists(Collection('users')), true, Delete(Collection('users')))),
     'Delete users collection'
   )
-  await handle(
-    client.query(If(Exists(Index('users_by_handle')), true, Delete(Index('users_by_handle')))),
-    'Delete users_by_handle index'
+  await alias(
+    client.query(If(Exists(Index('users_by_alias')), true, Delete(Index('users_by_alias')))),
+    'Delete users_by_alias index'
   )
-  await handle(client.query(If(Exists(Index('all_users')), true, Delete(Index('all_users')))), 'Delete all_users index')
-  await handle(
+  await alias(client.query(If(Exists(Index('all_users')), true, Delete(Index('all_users')))), 'Delete all_users index')
+  await alias(
     client.query(If(Exists(Index('users_by_account')), true, Delete(Index('users_by_account')))),
     'Delete users_by_account index'
   )
@@ -94,7 +94,7 @@ export {
   CreateUsersCollection,
   CreateUsersByAccount,
   DeleteAllUsers,
-  CreateUsersByHandle,
+  CreateUsersByAlias,
   createUsersCollection,
   deleteUsersCollection
 }

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -8,9 +8,9 @@ import { useHistory } from 'react-router-dom'
 // Components
 import Form from './../components/form'
 
-const handleRegister = (event, username, password, handle, name, sessionContext, history) => {
+const handleRegister = (event, username, password, alias, name, sessionContext, history) => {
   faunaQueries
-    .register(username, password, name, handle)
+    .register(username, password, name, alias)
     .then(e => {
       toast.success('User registered')
       sessionContext.dispatch({ type: 'register', data: e })
@@ -52,11 +52,11 @@ const handleRegister = (event, username, password, handle, name, sessionContext,
 const Register = () => {
   const history = useHistory()
   const sessionContext = useContext(SessionContext)
-  return (
+  return ( 
     <Form
       isLogin={false}
-      handleSubmit={(event, username, password, handle, name) =>
-        handleRegister(event, username, password, handle, name, sessionContext, history)
+      handleSubmit={(event, username, password, alias, name) =>
+        handleRegister(event, username, password, alias, name, sessionContext, history)
       }
     ></Form>
   )

--- a/src/pages/user.js
+++ b/src/pages/user.js
@@ -12,7 +12,7 @@ import { safeVerifyError } from '../fauna/helpers/errors'
 
 const UserPage = () => {
   // The userid in the url
-  const { authorHandle } = useParams()
+  const { authorAlias } = useParams()
 
   const [state, setState] = useState({
     fweets: [],
@@ -28,7 +28,7 @@ const UserPage = () => {
     if (user) {
       setState({ error: null, fweets: [], loaded: false })
       faunaQueries
-        .getFweetsByAuthor(authorHandle)
+        .getFweetsByAuthor(authorAlias)
         .then(result => {
           console.log('fweets', result)
           setState({
@@ -52,7 +52,7 @@ const UserPage = () => {
           }
         })
     }
-  }, [user, authorHandle])
+  }, [user, authorAlias])
 
   const update = (fweets, loaded, error) => {
     setState({
@@ -66,7 +66,7 @@ const UserPage = () => {
     <React.Fragment>
       <Nav />
       <div className="fweeter-and-feed-container">
-        <div className="feed-title">{'@' + authorHandle}</div>
+        <div className="feed-title">{'@' + authorAlias}</div>
         <Feed update={update} error={state.error} loaded={state.loaded} fweets={state.fweets} />
       </div>
       {user ? <Search /> : null}

--- a/src/styling/components/card.scss
+++ b/src/styling/components/card.scss
@@ -131,7 +131,7 @@
     padding-right: 5px;
 }
 
-.fweet-header .fweet-handle {
+.fweet-header .fweet-alias {
     display: flex;
     font-weight: light;
    // color: rgba(255,255,255,0.3);

--- a/src/styling/components/search.scss
+++ b/src/styling/components/search.scss
@@ -66,7 +66,7 @@
   margin-bottom: $grid-unit / 2;
 }
 
-.search-result-name-and-handle {
+.search-result-name-and-alias {
   display: flex;
   flex: 1 1 auto;
   padding-left: 10px;
@@ -74,12 +74,12 @@
   
 }
 
-.search-result-name-and-handle .name {
+.search-result-name-and-alias .name {
   font-weight: 500;
   font-size: 14px;
 }
 
-.search-result-name-and-handle .handle {
+.search-result-name-and-alias .alias {
   font-size: 12px;
   color: $grey;
 }


### PR DESCRIPTION
renamed "handle" variable to "alias" to make it easier to search the code base for this variable without having to sort through all of the event handlers. i'm pretty sure i got them all. i went through it a few times and QAed everything, setting it up from scratch.

however, i also discovered that the optional child database line in the env file seems to break either the setup or populate. i had to remove it. this also happens on master though, so it is unrelated to these changes